### PR TITLE
feat: force auth for each transaction signature even if old not timed out

### DIFF
--- a/android/src/main/java/io/parity/signer/domain/storage/SeedRepository.kt
+++ b/android/src/main/java/io/parity/signer/domain/storage/SeedRepository.kt
@@ -48,27 +48,19 @@ class SeedRepository(
 		}
 	}
 
-	/**
-	 * Try to get phrases if timeout - request auth
-	 */
-	suspend fun getSeedPhrases(seedNames: List<String>): RepoResult<String> {
+	suspend fun getSeedPhrasesForceAuth(seedNames: List<String>): RepoResult<String> {
 		return try {
-			try {
-				getSeedPhrasesDangerous(seedNames)
-			} catch (e: UserNotAuthenticatedException) {
 				when (val authResult =
 					authentication.authenticate(activity)) {
 					AuthResult.AuthSuccess -> {
 						getSeedPhrasesDangerous(seedNames)
 					}
-
 					AuthResult.AuthError,
 					AuthResult.AuthFailed,
 					AuthResult.AuthUnavailable -> {
 						RepoResult.Failure(RuntimeException("auth error - $authResult"))
 					}
 				}
-			}
 		} catch (e: java.lang.Exception) {
 			Log.d("get seed failure", e.toString())
 			Toast.makeText(activity, "get seed failure: $e", Toast.LENGTH_LONG).show()

--- a/android/src/main/java/io/parity/signer/screens/scan/ScanViewModel.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/ScanViewModel.kt
@@ -433,7 +433,7 @@ class ScanViewModel : ViewModel() {
 		comment: String,
 		seedNames: List<String>,
 	): ActionResult? {
-		return when (val phrases = seedRepository.getSeedPhrases(seedNames)) {
+		return when (val phrases = seedRepository.getSeedPhrasesForceAuth(seedNames)) {
 			is RepoResult.Failure -> {
 				Log.w(TAG, "signature transactions failure ${phrases.error}")
 				null


### PR DESCRIPTION
Currently storage unlocked on android for 5 min. I am forcing auth on UI for some cases like removing certificate, login auth or exporting secrets.
For signing transaction old version was requring pin only if auth times out. 
Because user will need to scan qr code and pass result qr to camera back - it cannot happen accidentally I think. 
I not sure if forcing auth each time will improve user experience but those are changes as discussed in security channel.

maybe @tetekinandrey have some thoughts.