### PR TITLE
feat: make possible to sign transactions without state machine

### DIFF
--- a/android/src/main/java/io/parity/signer/domain/backend/ScanFlowInteractor.kt
+++ b/android/src/main/java/io/parity/signer/domain/backend/ScanFlowInteractor.kt
@@ -44,7 +44,7 @@ class ScanFlowInteractor {
 		navigator.navigate(Action.NAVBAR_SCAN)
 	}
 
-	suspend fun continueSigningTransaction(
+	suspend fun continuePerformTransaction(
 		comment: String,
 		seedPhrases: String
 	): ActionResult? {

--- a/android/src/main/java/io/parity/signer/domain/backend/ScanFlowInteractor.kt
+++ b/android/src/main/java/io/parity/signer/domain/backend/ScanFlowInteractor.kt
@@ -1,6 +1,5 @@
 package io.parity.signer.domain.backend
 
-import io.parity.signer.R
 import io.parity.signer.domain.FakeNavigator
 import io.parity.signer.domain.NavigationError
 import io.parity.signer.domain.Navigator
@@ -63,7 +62,7 @@ class ScanFlowInteractor {
 		)
 	}
 
-	suspend fun performTransaction(payload: String): OperationResult<ActionResult, TransactionError> {
+	suspend fun getTransaction(payload: String): OperationResult<ActionResult, TransactionError> {
 		resetMachineState()
 		return try {
 			OperationResult.Ok(

--- a/android/src/main/java/io/parity/signer/screens/scan/ScanViewModel.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/ScanViewModel.kt
@@ -440,7 +440,7 @@ class ScanViewModel : ViewModel() {
 			}
 
 			is RepoResult.Success -> {
-				scanFlowInteractor.continueSigningTransaction(
+				scanFlowInteractor.continuePerformTransaction(
 					comment,
 					phrases.result,
 				)

--- a/android/src/main/java/io/parity/signer/screens/scan/ScanViewModel.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/ScanViewModel.kt
@@ -80,7 +80,7 @@ class ScanViewModel : ViewModel() {
 			return
 		}
 		transactionIsInProgress.value = true
-		val navigateResponse = scanFlowInteractor.performTransaction(payload)
+		val navigateResponse = scanFlowInteractor.getTransaction(payload)
 
 		when (navigateResponse) {
 			is OperationResult.Err -> {

--- a/rust/navigator/src/lib.rs
+++ b/rust/navigator/src/lib.rs
@@ -79,20 +79,24 @@ pub fn init_navigation(db: sled::Db, seed_names: Vec<String>) -> Result<()> {
 }
 
 /// Generate transaction from qr codes assembled data
+///
 pub fn get_transaction(database: &sled::Db, payload: &str) -> Result<TransactionAction> {
 	//return mtransaction data??? to know which keys used to sign and transaction action
     Ok(TransactionState::new(database, details_str)?.action()?)
 }
 
-//todo validate password for key function create
+//todo create function to validate password for key function
 
+/// sign signing type transactions or perform stub transactions
+/// //todo devide into 2 - sign and perform stub
 /// all passwords should be validated separately before and here we just signing
 /// transaction, that can be bulk, and expecting that error should never ocure
-pub fn sign_transaction(database: &sled::Db,
-												//list of seeds if needed,
+pub fn perform_transaction(database: &sled::Db,
+												//list of seeds if needed - for sign type,
 												transaction_state: TransactionAction,
-												password: Option<&str>,//todo pass passwords for keys
-												) -> Result<()> {
+												password: Vec<&str>,//todo pass passwords for keys
+												) -> Result<Vec<(MultiSignature, SignatureType)>> {
+	//return list of signatures
 	match transaction_state.action() {
 		transaction_parsing::TransactionAction::Sign { .. } => {
 			let mut new = transaction_state.clone();
@@ -131,8 +135,7 @@ pub fn sign_transaction(database: &sled::Db,
 			s: _,
 			u: checksum,
 			stub: stub_nav,
-		} => match transaction_signing::handle_stub(&self.db, *checksum) {
-			//todo check when we actually executing this actions in state machine. Not when transaction signing happening looks like
+		} => match transaction_signing::handle_stub(&self.db, *checksum) { //save pending transaction to DB
 			Ok(()) => match stub_nav {
 				transaction_parsing::StubNav::AddSpecs {
 					n: network_specs_key,
@@ -164,7 +167,7 @@ pub fn sign_transaction(database: &sled::Db,
 		// 	do nothing
 		}
 		transaction_parsing::TransactionAction::Derivations { content: _ } => {
-			new_navstate = Navstate::clean_screen(Screen::SeedSelector);
+			// 	do nothing
 		}
 	},
 

--- a/rust/navigator/src/lib.rs
+++ b/rust/navigator/src/lib.rs
@@ -78,8 +78,13 @@ pub fn init_navigation(db: sled::Db, seed_names: Vec<String>) -> Result<()> {
     Ok(())
 }
 
+
+///todo dmitry add function to get transaction type and validate. It exeists - it's
+/// todo decode_sequence - but we need to add types from TransactionAction there
+/// for Example - for banana split and dyn derivations use specific function, or get_transaction() for rest
+
 /// Generate transaction from qr codes assembled data
-///
+/// todo dmitry support all types from above todo or make many functions for each transaction type
 pub fn get_transaction(database: &sled::Db, payload: &str) -> Result<TransactionAction> {
 	//return mtransaction data??? to know which keys used to sign and transaction action
     Ok(TransactionState::new(database, details_str)?.action()?)


### PR DESCRIPTION
## Purpose
1) Make it possible to get and sign transactions without state machine - last peace why we need it
2) Remote state machine from rust and clients

## Scope
Looks like it's doable job, work in progress.
Need to cleanup and maybe move signing logic to another crate when it's working.


##  Added API last peace of state-machine used
pub fn sign_transaction(
pub fn get_transaction(


## TODOs
- [ ] finish signing - it's in comments what should be done there
- [ ] Move signing logic to more appropriate place
- [ ] describe api with uniffi
- [ ] adopt android and remove state machine
- [ ] adopt ios and remove state machine
- [ ] remove state machine from rust



## Discussion
Move signing logic from lib.rs, where?


