### PR TITLE
fix: updated vulnarable libs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -43,7 +43,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.14",
  "once_cell",
  "version_check",
 ]
@@ -1376,14 +1376,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1422,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -2233,7 +2233,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -2978,7 +2978,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -3119,9 +3119,23 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
+dependencies = [
+ "cc",
+ "getrandom 0.2.14",
+ "libc",
+ "spin 0.9.3",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3171,13 +3185,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki 0.101.4",
+ "ring 0.17.3",
+ "rustls-webpki 0.101.7",
  "sct",
 ]
 
@@ -3208,18 +3222,18 @@ version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.3",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3423,8 +3437,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -4214,7 +4228,7 @@ dependencies = [
  "derivative",
  "frame-metadata 15.1.0",
  "futures",
- "getrandom 0.2.6",
+ "getrandom 0.2.14",
  "hex",
  "impl-serde",
  "parity-scale-codec",
@@ -4915,6 +4929,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4972,12 +4992,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"


### PR DESCRIPTION
Those were vulnarable due to cargo-deny check: rustls and h2

Note - those added and removed - transitive dependencies




## Errors fixed:

```
rror[vulnerability]: Degradation of service in h2 servers with CONTINUATION Flood
    ┌─ /github/workspace/rust/Cargo.lock:148:1
    │
148 │ h2 0.3.24 registry+https://github.com/rust-lang/crates.io-index
    │ --------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2024-0332
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0332
    = An attacker can send a flood of CONTINUATION frames, causing `h2` to process them indefinitely.
      This results in an increase in CPU usage.
      
      Tokio task budget helps prevent this from a complete denial-of-service, as the server can still
      respond to legitimate requests, albeit with increased latency.
      
      More details at "[https://seanmonstar.com/blog/hyper-http2-continuation-flood/.](https://seanmonstar.com/blog/hyper-http2-continuation-flood/)
      
      Patches available for 0.4.x and 0.3.x versions.
    = Solution: Upgrade to ^0.3.26 OR >=0.4.4 (try `cargo update -p h2`)
    = h2 v0.3.24
      └── hyper v0.14.20
          ├── hyper-rustls v0.24.1
          │   └── jsonrpsee-http-client v0.16.3
          │       └── jsonrpsee v0.16.3
          │           └── subxt-codegen v0.27.1
          │               └── subxt-macro v0.27.1
          │                   └── subxt v0.27.1
          │                       └── (dev) parser v0.1.0
          │                           ├── (dev) navigator v0.1.0
          │                           │   └── signer v0.1.0
          │                           ├── signer v0.1.0 (*)
          │                           └── transaction_parsing v0.1.0
          │                               ├── navigator v0.1.0 (*)
          │                               ├── qr_reader_phone v0.1.0
          │                               │   ├── qr_reader_pc v0.2.0
          │                               │   └── signer v0.1.0 (*)
          │                               ├── signer v0.1.0 (*)
          │                               └── (dev) transaction_signing v0.1.0
          │                                   ├── navigator v0.1.0 (*)
          │                                   └── signer v0.1.0 (*)
          ├── jsonrpsee-core v0.16.3
          │   ├── jsonrpsee v0.16.3 (*)
          │   ├── jsonrpsee-client-transport v0.16.3
          │   │   └── jsonrpsee v0.16.3 (*)
          │   └── jsonrpsee-http-client v0.16.3 (*)
          └── jsonrpsee-http-client v0.16.3 (*)
```



```
 error[vulnerability]: `rustls::ConnectionCommon::complete_io` could fall into an infinite loop based on network input
    ┌─ /github/workspace/rust/Cargo.lock:322:1
    │
322 │ rustls 0.21.6 registry+https://github.com/rust-lang/crates.io-index
    │ ------------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2024-0336
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0336
    = If a `close_notify` alert is received during a handshake, `complete_io`
      does not terminate.
      
      Callers which do not call `complete_io` are not affected.
      
      `rustls-tokio` and `rustls-ffi` do not call `complete_io`
      and are not affected.
      
      `rustls::Stream` and `rustls::StreamOwned` types use
      `complete_io` and are affected.
    = Announcement: https://github.com/rustls/rustls/security/advisories/GHSA-6g7w-8wpp-frhj
    = Solution: Upgrade to >=0.23.5 OR >=0.22.4, <0.23.0 OR >=0.21.11, <0.22.0 (try `cargo update -p rustls`)
    = rustls v0.21.6
      ├── hyper-rustls v0.24.1
      │   └── jsonrpsee-http-client v0.16.3
      │       └── jsonrpsee v0.16.3
      │           └── subxt-codegen v0.27.1
      │               └── subxt-macro v0.27.1
      │                   └── subxt v0.27.1
      │                       └── (dev) parser v0.1.0
      │                           ├── (dev) navigator v0.1.0
      │                           │   └── signer v0.1.0
      │                           ├── signer v0.1.0 (*)
      │                           └── transaction_parsing v0.1.0
      │                               ├── navigator v0.1.0 (*)
      │                               ├── qr_reader_phone v0.1.0
      │                               │   ├── qr_reader_pc v0.2.0
      │                               │   └── signer v0.1.0 (*)
      │                               ├── signer v0.1.0 (*)
      │                               └── (dev) transaction_signing v0.1.0
      │                                   ├── navigator v0.1.0 (*)
      │                                   └── signer v0.1.0 (*)
      └── tokio-rustls v0.24.1
          ├── hyper-rustls v0.24.1 (*)
          ├── jsonrpsee-client-transport v0.16.3
          │   └── jsonrpsee v0.16.3 (*)
          └── jsonrpsee-client-transport v0.20.3
              └── jsonrpsee-ws-client v0.20.3
                  └── jsonrpsee v0.20.3
                      └── generate_message v0.1.0
                          └── (build) signer v0.1.0 (*)
```