### PR TITLE
Revert "chore(deps): bump raptorq from 1.8.1 to 2.0.0 in /rust"

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3001,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "raptorq"
-version = "2.0.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b1b1fad69672f0b901b5004863ea4307f03d168a3db5f2bcba4d3dfed88e97"
+checksum = "7cc8cd0bcb2d520fff368264b5a6295e064c60955349517d09b14473afae4856"
 
 [[package]]
 name = "rayon"

--- a/rust/qr_reader_phone/Cargo.toml
+++ b/rust/qr_reader_phone/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 hex = "0.4.3"
-raptorq = "2.0.0"
+raptorq = "1.8.1"
 nom = "7.1.3"
 thiserror = "1.0.57"
 constants = {path = "../constants"}

--- a/rust/qrcode_rtx/Cargo.toml
+++ b/rust/qrcode_rtx/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 bitvec = "1.0.1"
 hex = "0.4.3"
-raptorq = "2.0.0"
+raptorq = "1.8.1"
 qrcodegen = "1.8.0"
 png = "0.17.13"
 


### PR DESCRIPTION
Reverts novasamatech/parity-signer#2372

This bump resulted in backward-incomatible update of raptorq format. We should revert it (for now) since tooling  is not ready for that