### PR TITLE
Fix: Password intersection with borders when importing keyset via banana split

### DIFF
--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C2F8C4D2D512C34003A9DA0 /* PlainTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2F8C4C2D512C34003A9DA0 /* PlainTextField.swift */; };
 		2D48F35127609CDE004B27BE /* HistoryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D48F35027609CDE004B27BE /* HistoryCard.swift */; };
 		2D48F3532760A2D8004B27BE /* PrimaryFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D48F3522760A2D8004B27BE /* PrimaryFont.swift */; };
 		2D48F3D2277A0AB2004B27BE /* HistoryCardExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D48F3D1277A0AB2004B27BE /* HistoryCardExtended.swift */; };
@@ -427,6 +428,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0C2F8C4C2D512C34003A9DA0 /* PlainTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextField.swift; sourceTree = "<group>"; };
 		2D48F35027609CDE004B27BE /* HistoryCard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryCard.swift; sourceTree = "<group>"; };
 		2D48F3522760A2D8004B27BE /* PrimaryFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryFont.swift; sourceTree = "<group>"; };
 		2D48F3D1277A0AB2004B27BE /* HistoryCardExtended.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryCardExtended.swift; sourceTree = "<group>"; };
@@ -2273,6 +2275,7 @@
 				6D932CE5292E0CE6008AD883 /* PrimaryTextField.swift */,
 				6DA08B8729ACFC230027CFCB /* InlineTextField.swift */,
 				6D850BE1292F85F200BA9017 /* SecuredTextField.swift */,
+				0C2F8C4C2D512C34003A9DA0 /* PlainTextField.swift */,
 			);
 			path = TextFields;
 			sourceTree = "<group>";
@@ -2656,6 +2659,7 @@
 				6DF5E7A42923DD4400F2B5B4 /* Text+Markdown.swift in Sources */,
 				6D7DE0D42ACB178800BFAACA /* DatabaseVersionMediator.swift in Sources */,
 				6DDEF13228AE6039004CA2FD /* signer.udl in Sources */,
+				0C2F8C4D2D512C34003A9DA0 /* PlainTextField.swift in Sources */,
 				6DF8316728F9BA4A00CB2BCE /* CapsuleButton.swift in Sources */,
 				6DCC572728D8C0490014278A /* BackupModal.swift in Sources */,
 				6DDD73732940471900F04CE7 /* Event+AdditionalValue.swift in Sources */,

--- a/ios/PolkadotVault/Components/TextFields/PlainTextField.swift
+++ b/ios/PolkadotVault/Components/TextFields/PlainTextField.swift
@@ -1,0 +1,45 @@
+//
+//  SecuredTextField.swift
+//  Polkadot Vault
+//
+//  Created by Ruslan Rezin on 03/02/2025.
+//
+
+import SwiftUI
+
+struct PlainTextFieldStyle: ViewModifier {
+    let placeholder: String
+    let keyboardType: UIKeyboardType
+    @Binding var text: String
+    @Binding var isValid: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .foregroundColor(isValid ? .textAndIconsPrimary : .accentRed300)
+            .placeholder(placeholder, when: text.isEmpty)
+            .font(PrimaryFont.bodyL.font)
+            .autocapitalization(.none)
+            .disableAutocorrection(true)
+            .keyboardType(keyboardType)
+            .submitLabel(.return)
+            .frame(height: Heights.textFieldHeight)
+    }
+}
+
+extension View {
+    func plainTextFieldStyle(
+        _ placeholder: String,
+        keyboardType: UIKeyboardType = .asciiCapable,
+        text: Binding<String>,
+        isValid: Binding<Bool> = Binding<Bool>.constant(true)
+    ) -> some View {
+        modifier(
+            PlainTextFieldStyle(
+                placeholder: placeholder,
+                keyboardType: keyboardType,
+                text: text,
+                isValid: isValid
+            )
+        )
+    }
+}

--- a/ios/PolkadotVault/Components/TextFields/SecuredTextField.swift
+++ b/ios/PolkadotVault/Components/TextFields/SecuredTextField.swift
@@ -22,7 +22,7 @@ struct SecurePrimaryTextField: View {
     var onCommit: (() -> Void) = {}
 
     var body: some View {
-        ZStack(alignment: .trailing) {
+			HStack(alignment: .center, spacing: Spacing.minimal) {
             ZStack {
                 SecureField("", text: $text, onCommit: {
                     onCommit()
@@ -39,7 +39,7 @@ struct SecurePrimaryTextField: View {
                 .focused($focusedField, equals: .plain)
                 .opacity(isSecured ? 0 : 1)
             }
-            .primaryTextFieldStyle(placeholder, text: $text, isValid: $isValid)
+						.plainTextFieldStyle(placeholder, text: $text, isValid: $isValid)
             .onChange(of: text) { _ in
                 isValid = true
             }
@@ -50,9 +50,10 @@ struct SecurePrimaryTextField: View {
                 }
             ) {
                 Image(isSecured ? .showPassword : .hidePassword)
-                    .padding(.trailing, Spacing.medium)
                     .foregroundColor(.textAndIconsTertiary)
             }
         }
+        .padding(.horizontal, Spacing.medium)
+        .containerBackground(CornerRadius.small, state: isValid ? .standard : .error)
     }
 }


### PR DESCRIPTION
## Purpose
<!-- What is the goal of the proposed change? i.e.
This PR aims to address issue: #1234
This PR adds XYZ feature
This PR adds new GA workflow that runs unit tests
-->

When a user imports keyset via banansplit and enters the password from it the text field can intersect the eye button

## Scope
<!-- What is the technical scope of the changes? i.e.:
- refactored module XYZ
- added unit tests for ABC
-->

- added a separate modifier for plain textfield
- refactored SecureTextField to use horizontal stack instead of ZStack to layout text field and eye button

<!-- Optional sections
Starting from here, following sections are optional.
Move any section that you need above this comment block and delete the rest of the template starting from this comment block.
-->

<!--
This captures anything that should be addressed before merging PR
-->
## TODOs
<!--
- [ ] Discuss and update [README](https://github.com/paritytech/parity-signer/blob/master/README.md) if needed
- [ ] Make sure that this doesn't break feature ABC before merging
-->


<!--
This captures anything that's worth bringing up to team mates regarding content of the PR, approach, etc.
-->
## Discussion
<!--
I've tried approach XYZ which seems more viable but run into ABC issue.
-->

<!--
If your PR introduce UI change, please include screenshots / gifs that show how app UI was affected
-->
## Screenshots
<!--
| Left title, i.e. "Before" | Right title, i.e. "After" |
|-|-|
|<img src="IMG_URL" width="320px">|<img src="IMG_URL" width="320px">|
-->

![Screenshot 2025-02-05 at 10 00 39](https://github.com/user-attachments/assets/a5951405-afd8-4932-b51e-47c1887dae70)

