### PR TITLE
fix: opencv backwards compatibility

### DIFF
--- a/rust/qr_reader_pc/src/lib.rs
+++ b/rust/qr_reader_pc/src/lib.rs
@@ -13,9 +13,8 @@ use indicatif::ProgressBar;
 use qr_reader_phone::process_payload::{process_decoded_payload, InProgress, Ready};
 
 use opencv::{
-    core::AlgorithmHint,
     highgui,
-    imgproc::{cvt_color, COLOR_BGR2GRAY},
+    imgproc::{cvt_color_def, COLOR_BGR2GRAY},
     prelude::*,
     videoio,
     videoio::{CAP_PROP_FRAME_HEIGHT, CAP_PROP_FRAME_WIDTH},
@@ -124,13 +123,7 @@ fn camera_capture(camera: &mut videoio::VideoCapture, window: &str) -> Result<Gr
     let mut image: GrayImage = ImageBuffer::new(DEFAULT_WIDTH, DEFAULT_HEIGHT);
     let mut ocv_gray_image = Mat::default();
 
-    cvt_color(
-        &frame,
-        &mut ocv_gray_image,
-        COLOR_BGR2GRAY,
-        0,
-        AlgorithmHint::ALGO_HINT_DEFAULT,
-    )?;
+    cvt_color_def(&frame, &mut ocv_gray_image, COLOR_BGR2GRAY)?;
 
     for y in 0..ocv_gray_image.rows() {
         for x in 0..ocv_gray_image.cols() {


### PR DESCRIPTION
## Purpose
We were updating the metadata-portal to be compatible with newer version of opencv and had to realize that the way opencv is used in the rust library of the signer is not backward compatible (see #2429 for details).

As the signer does not make use of the additional flags available in newer opencv, there is actually no reason to not be backwards compatible, so this PR fixes that. 

This has been tested with the latest version of the metadata-portal and the changes proposed in paritytech/metadata-portal#845. The result is that the metadata-portal can be build with older and newer version of opencv without any issues.

## Scope
Use different opencv binding that assumes default 

@ERussel @stepanLav 