### PR TITLE
fix: banana split onboarding

### DIFF
--- a/ios/PolkadotVault/Core/JailbreakDetectionPublisher.swift
+++ b/ios/PolkadotVault/Core/JailbreakDetectionPublisher.swift
@@ -90,7 +90,13 @@ private extension JailbreakDetectionPublisher {
 }
 
 extension UIDevice: DeviceProtocol {
-    var isSimulator: Bool { TARGET_OS_SIMULATOR != 0 }
+    var isSimulator: Bool {
+        #if targetEnvironment(simulator)
+            true
+        #else
+            false
+        #endif
+    }
 }
 
 private enum Constants {

--- a/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
@@ -47,6 +47,15 @@ extension AuthenticatedScreenContainer {
         case loading
         case keyDetails(String)
         case noKeys
+
+        var isKeyDetails: Bool {
+            switch self {
+            case .keyDetails:
+                true
+            default:
+                false
+            }
+        }
     }
 
     final class ViewModel: ObservableObject {
@@ -59,11 +68,15 @@ extension AuthenticatedScreenContainer {
         init(seedsMediator: SeedsMediating = ServiceLocator.seedsMediator) {
             self.seedsMediator = seedsMediator
             updateViewState()
-            seedsMediator.seedNamesPublisher
-                .sink { [weak self] _ in
-                    self?.updateViewState()
-                }
-                .store(in: cancelBag)
+
+			/*
+			 * 	We monitor seed changes for keyDetails state only since
+			 *	for onboarding onKeySetAddCompletion used
+			 */
+			seedsMediator.seedNamesPublisher
+				.sink { [weak self] _ in
+					self?.updateKeyDetailsState()
+				}.store(in: cancelBag)
         }
 
         func onKeySetAddCompletion(_ completionAction: CreateKeysForNetworksView.OnCompletionAction) {
@@ -88,6 +101,12 @@ extension AuthenticatedScreenContainer {
             } else {
                 viewState = .noKeys
             }
+        }
+
+        func updateKeyDetailsState() {
+            guard viewState.isKeyDetails else { return }
+
+            updateViewState()
         }
     }
 }

--- a/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
@@ -69,14 +69,12 @@ extension AuthenticatedScreenContainer {
             self.seedsMediator = seedsMediator
             updateViewState()
 
-					/*
-					 * 	We monitor seed changes for keyDetails state only since
-					 *	for onboarding onKeySetAddCompletion used
-					 */
-					seedsMediator.seedNamesPublisher
-						.sink { [weak self] _ in
-							self?.updateKeyDetailsState()
-						}.store(in: cancelBag)
+            // 	We monitor seed changes for keyDetails state only since
+            // 	for onboarding onKeySetAddCompletion used
+            seedsMediator.seedNamesPublisher
+                .sink { [weak self] _ in
+                    self?.updateKeyDetailsState()
+                }.store(in: cancelBag)
         }
 
         func onKeySetAddCompletion(_ completionAction: CreateKeysForNetworksView.OnCompletionAction) {

--- a/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
@@ -69,14 +69,14 @@ extension AuthenticatedScreenContainer {
             self.seedsMediator = seedsMediator
             updateViewState()
 
-			/*
-			 * 	We monitor seed changes for keyDetails state only since
-			 *	for onboarding onKeySetAddCompletion used
-			 */
-			seedsMediator.seedNamesPublisher
-				.sink { [weak self] _ in
-					self?.updateKeyDetailsState()
-				}.store(in: cancelBag)
+					/*
+					 * 	We monitor seed changes for keyDetails state only since
+					 *	for onboarding onKeySetAddCompletion used
+					 */
+					seedsMediator.seedNamesPublisher
+						.sink { [weak self] _ in
+							self?.updateKeyDetailsState()
+						}.store(in: cancelBag)
         }
 
         func onKeySetAddCompletion(_ completionAction: CreateKeysForNetworksView.OnCompletionAction) {


### PR DESCRIPTION
## Purpose

This PR aims to address issue: #2445

## Scope

Due to the fact that seeds creation update handler immediately tries to change view hierarchy it conflicts with several modal views presented above `NoKeySetView`. From the other hand the onboarding flow always calls the `onKeySetAddCompletion` once keys are added. Thus one can fully rely on the completion closure for onboarding to update the state once flow is fully dismissed. Updating the view hierarchy based on SeedMediator subscription still needed for some cases in the `keyDetails` state such as wipe.

The PR also fixes the build issue with XCode 16.3 that removes TARGET_OS_* support
