### PR TITLE
fix: migration app store

### DIFF
--- a/ios/PolkadotVault/Core/Database/DatabaseMediator.swift
+++ b/ios/PolkadotVault/Core/Database/DatabaseMediator.swift
@@ -27,7 +27,8 @@ protocol DatabaseMediating: AnyObject {
 /// Class that should act as main accessor for database
 final class DatabaseMediator: DatabaseMediating {
     private enum Constants {
-        static let resource = "DatabaseV7_0_0"
+        static let bundleResource = "Database"
+        static let destinationResource = "DatabaseV7_0_0"
     }
 
     private let bundle: BundleProtocol
@@ -42,7 +43,8 @@ final class DatabaseMediator: DatabaseMediating {
             appropriateFor: nil,
             create: false
         )
-        return documentsURL?.appendingPathComponent(Constants.resource).path ?? ""
+        return documentsURL?
+            .appendingPathComponent(Constants.destinationResource).path ?? ""
     }
 
     init(
@@ -59,7 +61,9 @@ final class DatabaseMediator: DatabaseMediating {
 
     @discardableResult
     func recreateDatabaseFile() -> Bool {
-        guard let source = bundle.url(forResource: Constants.resource, withExtension: "") else { return false }
+        guard let source = bundle.url(forResource: Constants.bundleResource, withExtension: "") else {
+            return false
+        }
         do {
             var destination = try fileManager.url(
                 for: .documentDirectory,
@@ -67,7 +71,7 @@ final class DatabaseMediator: DatabaseMediating {
                 appropriateFor: nil,
                 create: true
             )
-            destination.appendPathComponent(Constants.resource)
+            destination.appendPathComponent(Constants.destinationResource)
             if fileManager.fileExists(atPath: databasePath) {
                 do {
                     try fileManager.removeItem(at: destination)

--- a/ios/PolkadotVault/Core/Database/DatabaseMediator.swift
+++ b/ios/PolkadotVault/Core/Database/DatabaseMediator.swift
@@ -27,7 +27,7 @@ protocol DatabaseMediating: AnyObject {
 /// Class that should act as main accessor for database
 final class DatabaseMediator: DatabaseMediating {
     private enum Constants {
-        static let resource = "Database"
+        static let resource = "DatabaseV7_0_0"
     }
 
     private let bundle: BundleProtocol

--- a/ios/PolkadotVaultTests/StateMediators/DatabaseMediatorTests.swift
+++ b/ios/PolkadotVaultTests/StateMediators/DatabaseMediatorTests.swift
@@ -9,6 +9,8 @@
 import XCTest
 
 final class DatabaseMediatorTests: XCTestCase {
+    static let expectedDatabaseName = "DatabaseV7_0_0"
+
     private var bundle: BundleProtocolMock!
     private var fileManager: FileManagingProtocolMock!
     private var subject: DatabaseMediator!
@@ -40,7 +42,7 @@ final class DatabaseMediatorTests: XCTestCase {
             appropriateFor: nil,
             create: false
         )
-        let expectedValue = documentsURL?.appendingPathComponent("Database").path ?? ""
+        let expectedValue = documentsURL?.appendingPathComponent(Self.expectedDatabaseName).path ?? ""
 
         // When
         let result = subject.databaseName
@@ -57,7 +59,7 @@ final class DatabaseMediatorTests: XCTestCase {
             appropriateFor: nil,
             create: false
         )
-        let expectedValue = documentsURL?.appendingPathComponent("Database").path ?? ""
+        let expectedValue = documentsURL?.appendingPathComponent(Self.expectedDatabaseName).path ?? ""
 
         // When
         _ = subject.isDatabaseAvailable()
@@ -94,7 +96,8 @@ final class DatabaseMediatorTests: XCTestCase {
 
     func test_wipeDatabase_removesFileAtExpectedDestination() {
         // Given
-        let expectedPathUrl = fileManager.urlForInAppropriateForCreateReturnValue.appendingPathComponent("Database")
+        let expectedPathUrl = fileManager.urlForInAppropriateForCreateReturnValue
+            .appendingPathComponent(Self.expectedDatabaseName)
 
         // When
         subject.wipeDatabase()
@@ -169,7 +172,8 @@ final class DatabaseMediatorTests: XCTestCase {
 
     func test_recreateDatabaseFile_whenFileExists_removesFileAtExpectedDestination() {
         // Given
-        let expectedPathUrl = fileManager.urlForInAppropriateForCreateReturnValue.appendingPathComponent("Database")
+        let expectedPathUrl = fileManager.urlForInAppropriateForCreateReturnValue
+            .appendingPathComponent(Self.expectedDatabaseName)
         fileManager.fileExistsAtPathReturnValue = true
 
         // When


### PR DESCRIPTION
## Purpose

The PR introduces a fix to App Store migration. Since the is migrated to Novasama Technologies App Store the previous keychain/seeds will not be available to a user. However, the old database file still available to the application that introduces inconsistencies with the new keychain data. The solution is to change database filename and thus triggering database recreation after the migrated update is installed above old app version.