### PR TITLE
fix: cannot remove unfinished word content

### DIFF
--- a/android/src/main/java/io/parity/signer/screens/keysets/restore/KeysetRecoverViewModel.kt
+++ b/android/src/main/java/io/parity/signer/screens/keysets/restore/KeysetRecoverViewModel.kt
@@ -35,6 +35,7 @@ class KeysetRecoverViewModel : ViewModel() {
 
 	fun onUserInput(rawUserInput: String) {
 		val currentModel = _recoverSeed.value
+
 		if (currentModel.enteredWords.size <= KeysetRecoverModel.WORDS_CAP) {
 			if (rawUserInput.isEmpty()) {
 				_recoverSeed.update {
@@ -55,7 +56,7 @@ class KeysetRecoverViewModel : ViewModel() {
 				val input = rawUserInput.trim()
 					.lowercase() // word could be capitalized by keyboard autocompletion
 				val guessing = getGuessWords(input)
-				if (rawUserInput.endsWith(KeysetRecoverModel.SPACE_CHARACTER)) {
+				if (rawUserInput.length > 1 && rawUserInput.endsWith(KeysetRecoverModel.SPACE_CHARACTER)) {
 					if (guessing.contains(input)) {
 						onAddword(input)
 					}


### PR DESCRIPTION
Current logic always maintains `SPACE_CHARACTER` at the beginning of the unfinished word user input. When it sees that this character is missing, it assumes user wants to delete the previous word. 
However, when checking whether the current input is a full word, the logic checks that `rawUserInput.endsWith(KeysetRecoverModel.SPACE_CHARACTER)` which false-positevely triggers when the input is just `SPACE_CHARACTER`. So, the fix is to check for the length of the input in addition to the current check

Overall this logic should be refactored since it is hard to understand 3 level of nested if statements