### PR TITLE
fix: export and import of the derivations

### DIFF
--- a/.spellcheck/signer.dic
+++ b/.spellcheck/signer.dic
@@ -26,6 +26,7 @@ app's
 backend/S
 base58
 ss58
+sr25519
 h160
 biometric
 biometrics

--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ Try launching Studio from the shell (command assumes you are in the "Application
 ./Android\ Studio.app/Contents/MacOS/studio
 ```
 
+#### "build fails when runnning particular test"
+
+Try to enable features for the dependencies. For example,
+
+```
+cargo test -p navigator export_import_substrate_and_ethereum_addrs --features db_handling/active
+```
+
 # Release Android
 
 - Create PR with new app version updated

--- a/rust/constants/src/test_values.rs
+++ b/rust/constants/src/test_values.rs
@@ -37,6 +37,11 @@ pub fn alice_sr_polkadot() -> Vec<u8> {
     hex::decode("f606519cb8726753885cd4d0f518804a69a5e0badf36fee70feadd8044081730").unwrap()
 }
 
+/// Identicon for Alice ehtereum key with derivation `//polkadot`, `Ethereum` encryption
+pub fn alice_ethereum_polkadot() -> String {
+    "0xe9267b732a8e9c9444e46f3d04d4610a996d682d".to_string()
+}
+
 /// Identicon for Alice key with derivation `//westend`, `Sr25519` encryption
 pub fn alice_sr_westend() -> Vec<u8> {
     hex::decode("3efeca331d646d8a2986374bb3bb8d6e9e3cfcdd7c45c2b69104fab5d61d3f34").unwrap()

--- a/rust/constants/src/test_values.rs
+++ b/rust/constants/src/test_values.rs
@@ -37,7 +37,7 @@ pub fn alice_sr_polkadot() -> Vec<u8> {
     hex::decode("f606519cb8726753885cd4d0f518804a69a5e0badf36fee70feadd8044081730").unwrap()
 }
 
-/// Identicon for Alice ehtereum key with derivation `//polkadot`, `Ethereum` encryption
+/// Identicon for Alice ethereum key with derivation `//polkadot`, `Ethereum` encryption
 pub fn alice_ethereum_polkadot() -> String {
     "0xe9267b732a8e9c9444e46f3d04d4610a996d682d".to_string()
 }

--- a/rust/db_handling/src/cold_default.rs
+++ b/rust/db_handling/src/cold_default.rs
@@ -303,3 +303,28 @@ pub(crate) fn populate_cold_release(database: &sled::Db) -> Result<()> {
 pub fn populate_cold_nav_test(database: &sled::Db) -> Result<()> {
     cold_database_no_init(database, Purpose::TestNavigator)
 }
+
+/// Generate **not initiated** test cold database for `navigator` testing with Mythos network.
+pub fn populate_cold_nav_test_with_ethereum_based_networks(database: &sled::Db) -> Result<()> {
+    use constants::{METATREE, SETTREE, SPECSTREE, VERIFIERS};
+
+    database.drop_tree(SPECSTREE)?;
+    database.drop_tree(VERIFIERS)?;
+    database.drop_tree(METATREE)?;
+    database.drop_tree(SETTREE)?;
+    database.clear()?;
+
+    let mut batch = Batch::default();
+    for x in defaults::default_chainspecs_with_mythos().iter() {
+        let network_specs_key =
+            NetworkSpecsKey::from_parts(&x.specs.genesis_hash, &x.specs.encryption);
+        batch.insert(network_specs_key.key(), x.encode());
+    }
+
+    TrDbCold::new()
+        .set_network_specs(batch) // set default network specs including Mythos
+        .set_settings(default_cold_settings_init_later()?) // set general verifier and load default types
+        .set_verifiers(default_cold_verifiers()) // set default verifiers
+        .apply(database)?;
+    Ok(())
+}

--- a/rust/db_handling/src/cold_default.rs
+++ b/rust/db_handling/src/cold_default.rs
@@ -315,7 +315,7 @@ pub fn populate_cold_nav_test_with_ethereum_based_networks(database: &sled::Db) 
     database.clear()?;
 
     let mut batch = Batch::default();
-    for x in defaults::default_chainspecs_with_mythos().iter() {
+    for x in defaults::substrate_chainspecs_with_ethereum().iter() {
         let network_specs_key =
             NetworkSpecsKey::from_parts(&x.specs.genesis_hash, &x.specs.encryption);
         batch.insert(network_specs_key.key(), x.encode());

--- a/rust/db_handling/src/identities.rs
+++ b/rust/db_handling/src/identities.rs
@@ -58,8 +58,10 @@ use definitions::dynamic_derivations::{
     DynamicDerivationsResponseInfo,
 };
 use definitions::helpers::base58_or_eth_pubkey_to_multisigner;
-use definitions::helpers::{print_multisigner_as_base58_or_eth_address, print_multisigner_as_base58_or_eth_public_key};
 use definitions::helpers::{get_multisigner, unhex};
+use definitions::helpers::{
+    print_multisigner_as_base58_or_eth_address, print_multisigner_as_base58_or_eth_public_key,
+};
 use definitions::navigation::{DDDetail, DDKeySet, DDPreview, ExportedSet};
 use definitions::network_specs::NetworkSpecs;
 #[cfg(feature = "active")]
@@ -260,7 +262,7 @@ pub fn export_key_set_addrs(
             let specs = get_network_specs(database, id)?;
             let address_or_pub_key = print_multisigner_as_base58_or_eth_public_key(
                 &key.0,
-                Some(specs.specs.base58prefix)
+                Some(specs.specs.base58prefix),
             );
             derived_keys.push(AddrInfo {
                 address_or_pubkey: address_or_pub_key.clone(),
@@ -847,7 +849,8 @@ pub(crate) fn create_derivation_address(
     ss58_or_pubkey: &str,
     has_pwd: bool,
 ) -> Result<PrepData> {
-    let multisigner = base58_or_eth_pubkey_to_multisigner(ss58_or_pubkey, &network_specs.encryption)?;
+    let multisigner =
+        base58_or_eth_pubkey_to_multisigner(ss58_or_pubkey, &network_specs.encryption)?;
     do_create_address(
         database,
         input_batch_prep,

--- a/rust/db_handling/src/identities.rs
+++ b/rust/db_handling/src/identities.rs
@@ -57,8 +57,8 @@ use definitions::dynamic_derivations::{
     DynamicDerivationsAddressResponse, DynamicDerivationsAddressResponseV1,
     DynamicDerivationsResponseInfo,
 };
-use definitions::helpers::base58_or_eth_to_multisigner;
-use definitions::helpers::print_multisigner_as_base58_or_eth;
+use definitions::helpers::base58_or_eth_pubkey_to_multisigner;
+use definitions::helpers::{print_multisigner_as_base58_or_eth_address, print_multisigner_as_base58_or_eth_public_key};
 use definitions::helpers::{get_multisigner, unhex};
 use definitions::navigation::{DDDetail, DDKeySet, DDPreview, ExportedSet};
 use definitions::network_specs::NetworkSpecs;
@@ -197,10 +197,10 @@ pub struct SeedInfo {
 pub struct AddrInfo {
     /// Address in the network.
     ///
-    /// This is either `ss58` form for substrate-based chains or
-    /// h160 form for ethereum based
+    /// This is either `ss58` form for sr25519 chains or
+    /// public key form for ecdsa based
     /// chains
-    pub address: String,
+    pub address_or_pubkey: String,
 
     /// The derivation path of the key if user provided one
     pub derivation_path: Option<String>,
@@ -258,13 +258,12 @@ pub fn export_key_set_addrs(
 
         if let Some(id) = &key.1.network_id {
             let specs = get_network_specs(database, id)?;
-            let address = print_multisigner_as_base58_or_eth(
+            let address_or_pub_key = print_multisigner_as_base58_or_eth_public_key(
                 &key.0,
-                Some(specs.specs.base58prefix),
-                key.1.encryption,
+                Some(specs.specs.base58prefix)
             );
             derived_keys.push(AddrInfo {
-                address: address.clone(),
+                address_or_pubkey: address_or_pub_key.clone(),
                 derivation_path: if key.1.path.is_empty() {
                     None
                 } else {
@@ -437,7 +436,7 @@ pub fn process_dynamic_derivations_v1(
         };
         let encryption = derivation_request.encryption;
         derivations.push(DDDetail {
-            base58: print_multisigner_as_base58_or_eth(
+            base58: print_multisigner_as_base58_or_eth_address(
                 multisigner,
                 Some(network_specs.specs.base58prefix),
                 encryption,
@@ -586,7 +585,7 @@ pub fn inject_derivations_has_pwd(
             let multisigner_pwdless =
                 full_address_to_multisigner(full_address, derived_key.encryption)?;
             let multisigner =
-                base58_or_eth_to_multisigner(&derived_key.address, &derived_key.encryption)?;
+                base58_or_eth_pubkey_to_multisigner(&derived_key.address, &derived_key.encryption)?;
             derived_key.has_pwd = Some(multisigner_pwdless != multisigner);
         }
     }
@@ -845,10 +844,10 @@ pub(crate) fn create_derivation_address(
     path: &str,
     network_specs: &NetworkSpecs,
     seed_name: &str,
-    ss58: &str,
+    ss58_or_pubkey: &str,
     has_pwd: bool,
 ) -> Result<PrepData> {
-    let multisigner = base58_or_eth_to_multisigner(ss58, &network_specs.encryption)?;
+    let multisigner = base58_or_eth_pubkey_to_multisigner(ss58_or_pubkey, &network_specs.encryption)?;
     do_create_address(
         database,
         input_batch_prep,
@@ -1738,7 +1737,7 @@ pub fn export_secret_key(
         qr,
         pubkey: hex::encode(public_key),
         network_info,
-        base58: print_multisigner_as_base58_or_eth(
+        base58: print_multisigner_as_base58_or_eth_address(
             multisigner,
             Some(network_specs.specs.base58prefix),
             address_details.encryption,

--- a/rust/db_handling/src/interface_signer.rs
+++ b/rust/db_handling/src/interface_signer.rs
@@ -15,7 +15,7 @@ use definitions::{
     crypto::Encryption,
     helpers::{
         make_identicon_from_multisigner, multisigner_to_public, pic_meta,
-        print_multisigner_as_base58_or_eth,
+        print_multisigner_as_base58_or_eth_address,
     },
     keyring::{AddressKey, NetworkSpecsKey, VerifierKey},
     navigation::{
@@ -173,7 +173,7 @@ pub fn keys_by_seed_name(database: &sled::Db, seed_name: &str) -> Result<MKeysNe
         // TODO: root always prefix 42 for substrate.
         let address_key = hex::encode(AddressKey::new(root.0.clone(), None).key());
         MAddressCard {
-            base58: print_multisigner_as_base58_or_eth(&root.0, None, root.1.encryption),
+            base58: print_multisigner_as_base58_or_eth_address(&root.0, None, root.1.encryption),
             address_key,
             address,
         }
@@ -186,7 +186,7 @@ pub fn keys_by_seed_name(database: &sled::Db, seed_name: &str) -> Result<MKeysNe
 
             let identicon =
                 make_identicon_from_multisigner(&multisigner, address_details.identicon_style());
-            let base58 = print_multisigner_as_base58_or_eth(
+            let base58 = print_multisigner_as_base58_or_eth_address(
                 &multisigner,
                 Some(network_specs.specs.base58prefix),
                 network_specs.specs.encryption,
@@ -330,7 +330,7 @@ pub fn export_key(
             real_seed_name: address_details.seed_name,
         });
     }
-    let base58 = print_multisigner_as_base58_or_eth(
+    let base58 = print_multisigner_as_base58_or_eth_address(
         multisigner,
         Some(network_specs.base58prefix),
         network_specs.encryption,
@@ -501,7 +501,7 @@ fn dynamic_path_check_unhexed(
                     ..Default::default()
                 },
                 Ok(DerivationCheck::NoPassword(Some((multisigner, address_details)))) => {
-                    let address_base58 = print_multisigner_as_base58_or_eth(
+                    let address_base58 = print_multisigner_as_base58_or_eth_address(
                         &multisigner,
                         Some(ordered_network_specs.specs.base58prefix),
                         address_details.encryption,

--- a/rust/defaults/src/lib.rs
+++ b/rust/defaults/src/lib.rs
@@ -456,8 +456,10 @@ pub fn default_types_content() -> Result<ContentLoadTypes> {
 /// Generate network specs [`OrderedNetworkSpecs`] set for the default networks plus Mythos, for
 /// cold database
 #[cfg(feature = "active")]
-pub fn default_chainspecs_with_mythos() -> Vec<OrderedNetworkSpecs> {
+pub fn substrate_chainspecs_with_ethereum() -> Vec<OrderedNetworkSpecs> {
     let mut out: Vec<OrderedNetworkSpecs> = default_chainspecs();
+
+    let max_order = out.iter().max_by_key(|network| network.order);
 
     // Add Mythos network
     let mythos = OrderedNetworkSpecs {
@@ -477,7 +479,7 @@ pub fn default_chainspecs_with_mythos() -> Vec<OrderedNetworkSpecs> {
             title: String::from("Mythos"),
             unit: String::from("MYTH"),
         },
-        order: 3, // Adding after existing networks
+        order: max_order.map(|v| v.order + 1).unwrap_or(0)
     };
     out.push(mythos);
     out

--- a/rust/defaults/src/lib.rs
+++ b/rust/defaults/src/lib.rs
@@ -458,7 +458,7 @@ pub fn default_types_content() -> Result<ContentLoadTypes> {
 #[cfg(feature = "active")]
 pub fn default_chainspecs_with_mythos() -> Vec<OrderedNetworkSpecs> {
     let mut out: Vec<OrderedNetworkSpecs> = default_chainspecs();
-    
+
     // Add Mythos network
     let mythos = OrderedNetworkSpecs {
         specs: NetworkSpecs {
@@ -467,8 +467,9 @@ pub fn default_chainspecs_with_mythos() -> Vec<OrderedNetworkSpecs> {
             decimals: 18,
             encryption: Encryption::Ethereum,
             genesis_hash: H256::from_str(
-                "f6ee56e9c5277df5b4ce6ae9983ee88f3cbed27d31beeb98f9f84f997a1ab0b9"
-            ).expect("known value"),
+                "f6ee56e9c5277df5b4ce6ae9983ee88f3cbed27d31beeb98f9f84f997a1ab0b9",
+            )
+            .expect("known value"),
             logo: String::from("mythos"),
             name: String::from("mythos"),
             path_id: String::from("//mythos"),

--- a/rust/defaults/src/lib.rs
+++ b/rust/defaults/src/lib.rs
@@ -453,6 +453,35 @@ pub fn default_types_content() -> Result<ContentLoadTypes> {
     Ok(ContentLoadTypes::generate(&default_types_vec()?))
 }
 
+/// Generate network specs [`OrderedNetworkSpecs`] set for the default networks plus Mythos, for
+/// cold database
+#[cfg(feature = "active")]
+pub fn default_chainspecs_with_mythos() -> Vec<OrderedNetworkSpecs> {
+    let mut out: Vec<OrderedNetworkSpecs> = default_chainspecs();
+    
+    // Add Mythos network
+    let mythos = OrderedNetworkSpecs {
+        specs: NetworkSpecs {
+            base58prefix: 29972,
+            color: String::from("#262528"),
+            decimals: 18,
+            encryption: Encryption::Ethereum,
+            genesis_hash: H256::from_str(
+                "f6ee56e9c5277df5b4ce6ae9983ee88f3cbed27d31beeb98f9f84f997a1ab0b9"
+            ).expect("known value"),
+            logo: String::from("mythos"),
+            name: String::from("mythos"),
+            path_id: String::from("//mythos"),
+            secondary_color: String::from("#262626"),
+            title: String::from("Mythos"),
+            unit: String::from("MYTH"),
+        },
+        order: 3, // Adding after existing networks
+    };
+    out.push(mythos);
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/defaults/src/lib.rs
+++ b/rust/defaults/src/lib.rs
@@ -479,7 +479,7 @@ pub fn substrate_chainspecs_with_ethereum() -> Vec<OrderedNetworkSpecs> {
             title: String::from("Mythos"),
             unit: String::from("MYTH"),
         },
-        order: max_order.map(|v| v.order + 1).unwrap_or(0)
+        order: max_order.map(|v| v.order + 1).unwrap_or(0),
     };
     out.push(mythos);
     out

--- a/rust/definitions/src/derivations.rs
+++ b/rust/definitions/src/derivations.rs
@@ -21,7 +21,7 @@ pub struct DerivedKeyPreview {
     /// Address in the network.
     ///
     /// This is either `ss58` form for substrate-based chains or
-    /// h160 form for ethereum based chains
+    /// hex public key form for ethereum based chains (ecdsa)
     pub address: String,
 
     /// The derivation path of the key if user provided one

--- a/rust/definitions/src/helpers.rs
+++ b/rust/definitions/src/helpers.rs
@@ -200,7 +200,7 @@ pub fn print_multisigner_as_base58_or_eth_address(
 // This leaves an opportunity to restore the `MultiSigner` back if needed.
 pub fn print_multisigner_as_base58_or_eth_public_key(
     multi_signer: &MultiSigner,
-    optional_prefix: Option<u16>
+    optional_prefix: Option<u16>,
 ) -> String {
     match optional_prefix {
         Some(base58prefix) => {
@@ -212,9 +212,7 @@ pub fn print_multisigner_as_base58_or_eth_public_key(
                 MultiSigner::Sr25519(pubkey) => {
                     pubkey.to_ss58check_with_version(version_for_base58)
                 }
-                MultiSigner::Ecdsa(pubkey) => {
-                    print_ecdsa_public_key(pubkey)
-                }
+                MultiSigner::Ecdsa(pubkey) => print_ecdsa_public_key(pubkey),
             }
         }
         None => match multi_signer {
@@ -228,9 +226,7 @@ pub fn print_multisigner_as_base58_or_eth_public_key(
                     .expect("unable to make Ss58AddressFormat from `BareSr25519`");
                 pubkey.to_ss58check_with_version(version)
             }
-            MultiSigner::Ecdsa(pubkey) => {
-                print_ecdsa_public_key(pubkey)
-            }
+            MultiSigner::Ecdsa(pubkey) => print_ecdsa_public_key(pubkey),
         },
     }
 }
@@ -354,13 +350,12 @@ mod tests {
         let secret_key =
             hex::decode("46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a")
                 .unwrap();
-        let public = ecdsa::Pair::from_seed_slice(&secret_key)
-            .unwrap()
-            .public();
+        let public = ecdsa::Pair::from_seed_slice(&secret_key).unwrap().public();
         let multisigner = MultiSigner::Ecdsa(public);
 
         let hexpubkey = print_multisigner_as_base58_or_eth_public_key(&multisigner, None);
-        let result = base58_or_eth_pubkey_to_multisigner(&hexpubkey, &Encryption::Ethereum).unwrap();
+        let result =
+            base58_or_eth_pubkey_to_multisigner(&hexpubkey, &Encryption::Ethereum).unwrap();
         assert_eq!(result, multisigner);
     }
 

--- a/rust/definitions/src/helpers.rs
+++ b/rust/definitions/src/helpers.rs
@@ -1,6 +1,7 @@
 //! Common helper functions
 
 use hex;
+use sp_core::hexdisplay::AsBytesRef;
 use sp_core::{crypto::AccountId32, ecdsa, ed25519, sr25519};
 use sp_core::{
     crypto::{Ss58AddressFormat, Ss58Codec},
@@ -87,7 +88,7 @@ pub fn make_identicon_from_multisigner(
             }
         }
         IdenticonStyle::Jdenticon => Identicon::Jdenticon {
-            identity: print_multisigner_as_base58_or_eth(
+            identity: print_multisigner_as_base58_or_eth_address(
                 multisigner,
                 None,
                 multisigner_to_encryption(multisigner),
@@ -147,7 +148,7 @@ pub fn get_multisigner(public: &[u8], encryption: &Encryption) -> Result<MultiSi
 /// network-specific base58 prefix by providing `Some(value)` as `optional_prefix` or with
 /// [default](https://docs.rs/sp-core/6.0.0/sp_core/crypto/trait.Ss58Codec.html#method.to_ss58check)
 /// one by leaving it `None`.
-pub fn print_multisigner_as_base58_or_eth(
+pub fn print_multisigner_as_base58_or_eth_address(
     multi_signer: &MultiSigner,
     optional_prefix: Option<u16>,
     encryption: Encryption,
@@ -193,6 +194,47 @@ pub fn print_multisigner_as_base58_or_eth(
     }
 }
 
+/// Print [`MultiSigner`](https://docs.rs/sp-runtime/6.0.0/sp_runtime/enum.MultiSigner.html)
+/// in base58 format or hex public key for ecdsa.
+//
+// This leaves an opportunity to restore the `MultiSigner` back if needed.
+pub fn print_multisigner_as_base58_or_eth_public_key(
+    multi_signer: &MultiSigner,
+    optional_prefix: Option<u16>
+) -> String {
+    match optional_prefix {
+        Some(base58prefix) => {
+            let version_for_base58 = Ss58AddressFormat::custom(base58prefix);
+            match multi_signer {
+                MultiSigner::Ed25519(pubkey) => {
+                    pubkey.to_ss58check_with_version(version_for_base58)
+                }
+                MultiSigner::Sr25519(pubkey) => {
+                    pubkey.to_ss58check_with_version(version_for_base58)
+                }
+                MultiSigner::Ecdsa(pubkey) => {
+                    print_ecdsa_public_key(pubkey)
+                }
+            }
+        }
+        None => match multi_signer {
+            MultiSigner::Ed25519(pubkey) => {
+                let version = Ss58AddressFormat::try_from("BareEd25519")
+                    .expect("unable to make Ss58AddressFormat from `BareEd25519`");
+                pubkey.to_ss58check_with_version(version)
+            }
+            MultiSigner::Sr25519(pubkey) => {
+                let version = Ss58AddressFormat::try_from("BareSr25519")
+                    .expect("unable to make Ss58AddressFormat from `BareSr25519`");
+                pubkey.to_ss58check_with_version(version)
+            }
+            MultiSigner::Ecdsa(pubkey) => {
+                print_ecdsa_public_key(pubkey)
+            }
+        },
+    }
+}
+
 /// Turn a `ecdsa::Public` addr into an Ethereum address.
 pub fn ecdsa_public_to_eth_address(public: &ecdsa::Public) -> Result<H160> {
     let decompressed = libsecp256k1::PublicKey::parse_compressed(&public.0)?.serialize();
@@ -203,7 +245,7 @@ pub fn ecdsa_public_to_eth_address(public: &ecdsa::Public) -> Result<H160> {
     )))
 }
 
-/// Print a `ecdsa::Public` into `String`.
+/// Print a `ecdsa::Public` into Ethereum address `String`.
 ///
 /// Panics if provided ecdsa public key is in wrong format.
 fn print_ethereum_address(public: &ecdsa::Public) -> String {
@@ -212,7 +254,14 @@ fn print_ethereum_address(public: &ecdsa::Public) -> String {
     format!("0x{:?}", HexDisplay::from(&account.as_bytes()))
 }
 
-pub fn base58_or_eth_to_multisigner(
+/// Print a `ecdsa::Public` into Hex String `String`.
+///
+/// Panics if provided ecdsa public key is in wrong format.
+fn print_ecdsa_public_key(key: &ecdsa::Public) -> String {
+    format!("0x{:?}", HexDisplay::from(&key.0.as_bytes_ref()))
+}
+
+pub fn base58_or_eth_pubkey_to_multisigner(
     base58_or_eth: &str,
     encryption: &Encryption,
 ) -> Result<MultiSigner> {
@@ -226,7 +275,11 @@ pub fn base58_or_eth_to_multisigner(
             Ok(MultiSigner::Sr25519(pubkey))
         }
         Encryption::Ethereum | Encryption::Ecdsa => {
-            let pubkey = ecdsa::Public::from_ss58check(base58_or_eth)?;
+            let raw_key = unhex(base58_or_eth)?
+                .try_into()
+                .map_err(|_| Error::WrongPublicKeyLength)?;
+
+            let pubkey = ecdsa::Public::from_raw(raw_key);
             Ok(MultiSigner::Ecdsa(pubkey))
         }
     }
@@ -286,19 +339,33 @@ mod tests {
         let secret_key =
             hex::decode("46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a")
                 .unwrap();
-        let encryption = Encryption::Sr25519;
         let public = sr25519::Pair::from_seed_slice(&secret_key)
             .unwrap()
             .public();
         let multisigner = Sr25519(public);
 
-        let ss58 = print_multisigner_as_base58_or_eth(&multisigner, None, encryption);
-        let result = base58_or_eth_to_multisigner(&ss58, &Encryption::Sr25519).unwrap();
+        let ss58 = print_multisigner_as_base58_or_eth_public_key(&multisigner, None);
+        let result = base58_or_eth_pubkey_to_multisigner(&ss58, &Encryption::Sr25519).unwrap();
         assert_eq!(result, multisigner);
     }
 
     #[test]
-    fn test_print_multisigner_polkadot() {
+    fn test_ethereum_to_multisigner() {
+        let secret_key =
+            hex::decode("46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a")
+                .unwrap();
+        let public = ecdsa::Pair::from_seed_slice(&secret_key)
+            .unwrap()
+            .public();
+        let multisigner = MultiSigner::Ecdsa(public);
+
+        let hexpubkey = print_multisigner_as_base58_or_eth_public_key(&multisigner, None);
+        let result = base58_or_eth_pubkey_to_multisigner(&hexpubkey, &Encryption::Ethereum).unwrap();
+        assert_eq!(result, multisigner);
+    }
+
+    #[test]
+    fn test_print_multisigner_address_polkadot() {
         let multisigner = Sr25519(sr25519::Public(
             hex::decode("4a755d99a3cbafc1918769c292848bc87bc2e3cb3e09c17856a1c7d0c784b41c")
                 .unwrap()
@@ -306,13 +373,13 @@ mod tests {
                 .unwrap(),
         ));
         assert_eq!(
-            print_multisigner_as_base58_or_eth(&multisigner, Some(0), Encryption::Sr25519),
+            print_multisigner_as_base58_or_eth_address(&multisigner, Some(0), Encryption::Sr25519),
             "12gdQgfKFbiuba7hHS81MMr1rQH2amezrCbWixXZoUKzAm3q"
         );
     }
 
     #[test]
-    fn test_print_multisigner_no_network() {
+    fn test_print_multisigner_address_no_network() {
         let multisigner = Sr25519(sr25519::Public(
             hex::decode("4a755d99a3cbafc1918769c292848bc87bc2e3cb3e09c17856a1c7d0c784b41c")
                 .unwrap()
@@ -320,7 +387,7 @@ mod tests {
                 .unwrap(),
         ));
         assert_eq!(
-            print_multisigner_as_base58_or_eth(&multisigner, None, Encryption::Sr25519),
+            print_multisigner_as_base58_or_eth_address(&multisigner, None, Encryption::Sr25519),
             "8UHfgCidtbdkdXABy12jG7SVtRKdxHX399eLeAsGKvUT2U6"
         );
     }

--- a/rust/generate_message/src/helpers.rs
+++ b/rust/generate_message/src/helpers.rs
@@ -624,7 +624,7 @@ pub fn generate_key_info_export_to_qr<P: AsRef<Path>>(
 
     let derived_keys: Vec<AddrInfo> = (0..keys_num)
         .map(|num| AddrInfo {
-            address: "0xdeadbeefdeadbeefdeadbeef".to_string(),
+            address_or_pubkey: "0xdeadbeefdeadbeefdeadbeef".to_string(),
             derivation_path: Some(format!("//this//is//a//path//{num}")),
             encryption: Encryption::Sr25519,
             genesis_hash: H256::default(),

--- a/rust/navigator/src/lib.rs
+++ b/rust/navigator/src/lib.rs
@@ -26,7 +26,7 @@ mod error;
 mod actions;
 pub use actions::Action;
 use db_handling::helpers::get_address_details;
-use definitions::helpers::{make_identicon_from_multisigner, print_multisigner_as_base58_or_eth};
+use definitions::helpers::{make_identicon_from_multisigner, print_multisigner_as_base58_or_eth_address};
 use definitions::keyring::AddressKey;
 
 pub mod alerts;
@@ -229,7 +229,7 @@ pub fn sign_sufficient_content(
         .as_ref()
         .ok_or(Error::NoNetwork(address_details.path.clone()))?;
     let network_specs = db_handling::helpers::get_network_specs(database, network_key)?.specs;
-    let base58 = print_multisigner_as_base58_or_eth(
+    let base58 = print_multisigner_as_base58_or_eth_address(
         multisigner,
         Some(network_specs.base58prefix),
         network_specs.encryption,

--- a/rust/navigator/src/lib.rs
+++ b/rust/navigator/src/lib.rs
@@ -26,7 +26,9 @@ mod error;
 mod actions;
 pub use actions::Action;
 use db_handling::helpers::get_address_details;
-use definitions::helpers::{make_identicon_from_multisigner, print_multisigner_as_base58_or_eth_address};
+use definitions::helpers::{
+    make_identicon_from_multisigner, print_multisigner_as_base58_or_eth_address,
+};
 use definitions::keyring::AddressKey;
 
 pub mod alerts;

--- a/rust/navigator/src/tests.rs
+++ b/rust/navigator/src/tests.rs
@@ -8,14 +8,12 @@ use std::{collections::HashMap, convert::TryInto, fs, str::FromStr};
 
 use constants::{
     test_values::{
-        alice_sr_alice, alice_sr_alice_secret_secret, alice_sr_kusama, alice_sr_polkadot,
-        alice_sr_root, alice_sr_secret_path_multipass, alice_sr_westend, bob, kusama_9130,
-        kusama_9151, types_known,
+        alice_ethereum_polkadot, alice_sr_alice, alice_sr_alice_secret_secret, alice_sr_kusama, alice_sr_polkadot, alice_sr_root, alice_sr_secret_path_multipass, alice_sr_westend, bob, kusama_9130, kusama_9151, types_known
     },
     ALICE_SEED_PHRASE,
 };
 use db_handling::{
-    cold_default::{init_db, populate_cold_nav_test},
+    cold_default::{init_db, populate_cold_nav_test, populate_cold_nav_test_with_ethereum_based_networks},
     identities::{
         import_all_addrs, try_create_address, try_create_seed, TransactionBulk, TransactionBulkV1,
     },
@@ -675,8 +673,8 @@ fn export_import_substrate_and_ethereum_addrs() {
     let db_from = sled::open(dbname_from).unwrap();
     let db_to = sled::open(dbname_to).unwrap();
 
-    populate_cold_nav_test(&db_from).unwrap();
-    populate_cold_nav_test(&db_to).unwrap();
+    populate_cold_nav_test_with_ethereum_based_networks(&db_from).unwrap();
+    populate_cold_nav_test_with_ethereum_based_networks(&db_to).unwrap();
     try_create_seed(&db_from, "Alice", ALICE_SEED_PHRASE, true).unwrap();
     try_create_seed(&db_to, "Alice", ALICE_SEED_PHRASE, true).unwrap();
 
@@ -716,26 +714,26 @@ fn export_import_substrate_and_ethereum_addrs() {
             .into(),
         derived_keys: vec![
             DerivedKeyPreview {
-                address: "5EkMjdgyuHqnWA9oWXUoFRaMwMUgMJ1ik9KtMpPNuTuZTi2t".to_owned(),
+                address: "16Zaf6BT6xc6WeYCX6YNAf67RumWaEiumwawt7cTdKMU7HqW".to_owned(),
                 derivation_path: Some(derivation_path.to_string()),
                 encryption: Encryption::Sr25519,
                 genesis_hash: polkadot_genesis,
                 identicon: Identicon::Dots {
                     identity: alice_sr_polkadot().to_vec(),
                 },
-                has_pwd: Some(true),
+                has_pwd: Some(false),
                 network_title: Some("Polkadot".to_string()),
                 status: DerivedKeyStatus::AlreadyExists,
             },
             DerivedKeyPreview {
-                address: "5EkMjdgyuHqnWA9oWXUoFRaMwMUgMJ1ik9KtMpPNuTuZTi2t".to_owned(),
+                address: "0x02c08517b1ff9501d42ab480ea6fa1b9b92f0430fb07e4a9575dbb2d5ec6edb6d6".to_owned(),
                 derivation_path: Some(derivation_path.to_string()),
                 encryption: Encryption::Ethereum,
                 genesis_hash: mythos_genesis,
-                identicon: Identicon::Dots {
-                    identity: alice_sr_polkadot().to_vec(),
+                identicon: Identicon::Blockies {
+                    identity: alice_ethereum_polkadot(),
                 },
-                has_pwd: Some(true),
+                has_pwd: Some(false),
                 network_title: Some("Mythos".to_string()),
                 status: DerivedKeyStatus::AlreadyExists,
             },

--- a/rust/navigator/src/tests.rs
+++ b/rust/navigator/src/tests.rs
@@ -8,12 +8,16 @@ use std::{collections::HashMap, convert::TryInto, fs, str::FromStr};
 
 use constants::{
     test_values::{
-        alice_ethereum_polkadot, alice_sr_alice, alice_sr_alice_secret_secret, alice_sr_kusama, alice_sr_polkadot, alice_sr_root, alice_sr_secret_path_multipass, alice_sr_westend, bob, kusama_9130, kusama_9151, types_known
+        alice_ethereum_polkadot, alice_sr_alice, alice_sr_alice_secret_secret, alice_sr_kusama,
+        alice_sr_polkadot, alice_sr_root, alice_sr_secret_path_multipass, alice_sr_westend, bob,
+        kusama_9130, kusama_9151, types_known,
     },
     ALICE_SEED_PHRASE,
 };
 use db_handling::{
-    cold_default::{init_db, populate_cold_nav_test, populate_cold_nav_test_with_ethereum_based_networks},
+    cold_default::{
+        init_db, populate_cold_nav_test, populate_cold_nav_test_with_ethereum_based_networks,
+    },
     identities::{
         import_all_addrs, try_create_address, try_create_seed, TransactionBulk, TransactionBulkV1,
     },
@@ -666,8 +670,8 @@ fn export_import_substrate_and_ethereum_addrs() {
     let polkadot_genesis =
         H256::from_str("0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3")
             .unwrap();
-    
-    let mythos_genesis: H256 = 
+
+    let mythos_genesis: H256 =
         H256::from_str("f6ee56e9c5277df5b4ce6ae9983ee88f3cbed27d31beeb98f9f84f997a1ab0b9").unwrap();
 
     let db_from = sled::open(dbname_from).unwrap();
@@ -726,7 +730,8 @@ fn export_import_substrate_and_ethereum_addrs() {
                 status: DerivedKeyStatus::AlreadyExists,
             },
             DerivedKeyPreview {
-                address: "0x02c08517b1ff9501d42ab480ea6fa1b9b92f0430fb07e4a9575dbb2d5ec6edb6d6".to_owned(),
+                address: "0x02c08517b1ff9501d42ab480ea6fa1b9b92f0430fb07e4a9575dbb2d5ec6edb6d6"
+                    .to_owned(),
                 derivation_path: Some(derivation_path.to_string()),
                 encryption: Encryption::Ethereum,
                 genesis_hash: mythos_genesis,
@@ -745,7 +750,7 @@ fn export_import_substrate_and_ethereum_addrs() {
     let addrs_new = export_key_set_addrs(&db_to, "Alice", ExportedSet::All).unwrap();
     let addrs_new = prepare_derivations_preview(&db_to, addrs_new).unwrap();
     let addrs_new = inject_derivations_has_pwd(addrs_new, alice_seeds).unwrap();
-    
+
     assert_eq!(addrs_new, addrs_expected);
 }
 

--- a/rust/transaction_parsing/src/cards.rs
+++ b/rust/transaction_parsing/src/cards.rs
@@ -9,7 +9,7 @@ use definitions::derivations::SeedKeysPreview;
 use definitions::navigation::MAddressCard;
 use definitions::{
     crypto::Encryption,
-    helpers::{make_identicon_from_multisigner, pic_meta, print_multisigner_as_base58_or_eth},
+    helpers::{make_identicon_from_multisigner, pic_meta, print_multisigner_as_base58_or_eth_address},
     history::MetaValuesDisplay,
     keyring::VerifierKey,
     navigation::{
@@ -38,6 +38,7 @@ pub(crate) enum Card<'a> {
     AuthorPlain {
         author: &'a MultiSigner,
         base58prefix: u16,
+        encryption: Encryption
     },
     Verifier(&'a VerifierValue),
     Meta(MetaValuesDisplay),
@@ -216,12 +217,13 @@ impl Card<'_> {
             Card::AuthorPlain {
                 author,
                 base58prefix,
+                encryption
             } => NavCard::AuthorPlainCard {
                 f: MSCId {
-                    base58: print_multisigner_as_base58_or_eth(
+                    base58: print_multisigner_as_base58_or_eth_address(
                         author,
                         Some(*base58prefix),
-                        Encryption::Sr25519,
+                        *encryption,
                     ),
                     identicon: make_identicon_from_multisigner(author, IdenticonStyle::Dots),
                 },
@@ -295,7 +297,7 @@ pub(crate) fn make_author_info(
     address_details: &AddressDetails,
 ) -> MAddressCard {
     let base58 =
-        print_multisigner_as_base58_or_eth(author, Some(base58prefix), address_details.encryption);
+        print_multisigner_as_base58_or_eth_address(author, Some(base58prefix), address_details.encryption);
     let address_key = hex::encode(AddressKey::new(author.clone(), Some(genesis_hash)).key());
     MAddressCard {
         base58,

--- a/rust/transaction_parsing/src/cards.rs
+++ b/rust/transaction_parsing/src/cards.rs
@@ -9,7 +9,9 @@ use definitions::derivations::SeedKeysPreview;
 use definitions::navigation::MAddressCard;
 use definitions::{
     crypto::Encryption,
-    helpers::{make_identicon_from_multisigner, pic_meta, print_multisigner_as_base58_or_eth_address},
+    helpers::{
+        make_identicon_from_multisigner, pic_meta, print_multisigner_as_base58_or_eth_address,
+    },
     history::MetaValuesDisplay,
     keyring::VerifierKey,
     navigation::{
@@ -38,7 +40,7 @@ pub(crate) enum Card<'a> {
     AuthorPlain {
         author: &'a MultiSigner,
         base58prefix: u16,
-        encryption: Encryption
+        encryption: Encryption,
     },
     Verifier(&'a VerifierValue),
     Meta(MetaValuesDisplay),
@@ -217,7 +219,7 @@ impl Card<'_> {
             Card::AuthorPlain {
                 author,
                 base58prefix,
-                encryption
+                encryption,
             } => NavCard::AuthorPlainCard {
                 f: MSCId {
                     base58: print_multisigner_as_base58_or_eth_address(
@@ -296,8 +298,11 @@ pub(crate) fn make_author_info(
     genesis_hash: H256,
     address_details: &AddressDetails,
 ) -> MAddressCard {
-    let base58 =
-        print_multisigner_as_base58_or_eth_address(author, Some(base58prefix), address_details.encryption);
+    let base58 = print_multisigner_as_base58_or_eth_address(
+        author,
+        Some(base58prefix),
+        address_details.encryption,
+    );
     let address_key = hex::encode(AddressKey::new(author.clone(), Some(genesis_hash)).key());
     MAddressCard {
         base58,

--- a/rust/transaction_parsing/src/derivations.rs
+++ b/rust/transaction_parsing/src/derivations.rs
@@ -49,8 +49,10 @@ fn prepare_derivations_v1(
     for seed_info in export_info.addrs {
         let mut derived_keys = vec![];
         for addr_info in seed_info.derived_keys {
-            let multisigner =
-                base58_or_eth_pubkey_to_multisigner(&addr_info.address_or_pubkey, &addr_info.encryption)?;
+            let multisigner = base58_or_eth_pubkey_to_multisigner(
+                &addr_info.address_or_pubkey,
+                &addr_info.encryption,
+            )?;
             let identicon = make_identicon_from_multisigner(
                 &multisigner,
                 addr_info.encryption.identicon_style(),

--- a/rust/transaction_parsing/src/derivations.rs
+++ b/rust/transaction_parsing/src/derivations.rs
@@ -7,7 +7,7 @@ use definitions::derivations::{
 };
 
 use db_handling::helpers::get_network_specs;
-use definitions::helpers::{base58_or_eth_to_multisigner, make_identicon_from_multisigner};
+use definitions::helpers::{base58_or_eth_pubkey_to_multisigner, make_identicon_from_multisigner};
 use definitions::keyring::NetworkSpecsKey;
 use definitions::{helpers::unhex, navigation::TransactionCardSet};
 use parity_scale_codec::Decode;
@@ -50,7 +50,7 @@ fn prepare_derivations_v1(
         let mut derived_keys = vec![];
         for addr_info in seed_info.derived_keys {
             let multisigner =
-                base58_or_eth_to_multisigner(&addr_info.address, &addr_info.encryption)?;
+                base58_or_eth_pubkey_to_multisigner(&addr_info.address_or_pubkey, &addr_info.encryption)?;
             let identicon = make_identicon_from_multisigner(
                 &multisigner,
                 addr_info.encryption.identicon_style(),
@@ -70,7 +70,7 @@ fn prepare_derivations_v1(
                 &multisigner,
             )?;
             derived_keys.push(DerivedKeyPreview {
-                address: addr_info.address.clone(),
+                address: addr_info.address_or_pubkey.clone(),
                 derivation_path: addr_info.derivation_path,
                 identicon,
                 has_pwd: None, // unknown at this point

--- a/rust/transaction_parsing/src/message.rs
+++ b/rust/transaction_parsing/src/message.rs
@@ -99,6 +99,7 @@ pub fn process_message(database: &sled::Db, data_hex: &str) -> Result<Transactio
                     let author_card = Card::AuthorPlain {
                         author: &author_multi_signer,
                         base58prefix: network_specs.specs.base58prefix,
+                        encryption
                     }
                     .card(&mut index, indent);
                     let warning_card =

--- a/rust/transaction_parsing/src/message.rs
+++ b/rust/transaction_parsing/src/message.rs
@@ -99,7 +99,7 @@ pub fn process_message(database: &sled::Db, data_hex: &str) -> Result<Transactio
                     let author_card = Card::AuthorPlain {
                         author: &author_multi_signer,
                         base58prefix: network_specs.specs.base58prefix,
-                        encryption
+                        encryption,
                     }
                     .card(&mut index, indent);
                     let warning_card =

--- a/rust/transaction_parsing/src/parse_transaction.rs
+++ b/rust/transaction_parsing/src/parse_transaction.rs
@@ -185,7 +185,7 @@ fn do_parse_transaction_with_proof(
             (Card::AuthorPlain {
                 author: &author_multi_signer,
                 base58prefix: network_specs.specs.base58prefix,
-                encryption
+                encryption,
             })
             .card(&mut index, indent),
             Box::new((Card::Warning(Warning::AuthorNotFound)).card(&mut index, indent)),
@@ -449,7 +449,7 @@ fn do_parse_transaction(
                     (Card::AuthorPlain {
                         author: &author_multi_signer,
                         base58prefix: network_specs.specs.base58prefix,
-                        encryption
+                        encryption,
                     })
                     .card(&mut index, indent),
                     Box::new((Card::Warning(Warning::AuthorNotFound)).card(&mut index, indent)),

--- a/rust/transaction_parsing/src/parse_transaction.rs
+++ b/rust/transaction_parsing/src/parse_transaction.rs
@@ -185,6 +185,7 @@ fn do_parse_transaction_with_proof(
             (Card::AuthorPlain {
                 author: &author_multi_signer,
                 base58prefix: network_specs.specs.base58prefix,
+                encryption
             })
             .card(&mut index, indent),
             Box::new((Card::Warning(Warning::AuthorNotFound)).card(&mut index, indent)),
@@ -448,6 +449,7 @@ fn do_parse_transaction(
                     (Card::AuthorPlain {
                         author: &author_multi_signer,
                         base58prefix: network_specs.specs.base58prefix,
+                        encryption
                     })
                     .card(&mut index, indent),
                     Box::new((Card::Warning(Warning::AuthorNotFound)).card(&mut index, indent)),


### PR DESCRIPTION
## Purpose

Current logic of the `base58_or_eth_to_multisigner` assumes that the address provided can be converted back to the public key. That causes the issue since ecdsa addresses can't be converted back to the public key making impossible to import back exported derivations.

The PR fixes the issue in the following way:

- `print_multisigner_as_base58_or_eth` is renamed to the `print_multisigner_as_base58_or_eth_address` and is used solely to get address to display from a public key

- New `print_multisigner_as_base58_or_eth_public_key` function is introduced to use for the export of the derivations inside keysets. 

- `base58_or_eth_to_multisigner` is renamed to `base58_or_eth_pubkey_to_multisigner` and now assumes that ecdsa is represented by the hex of the public key

Fixes #2490 
