### PR TITLE
fix: iOS air gap mode detection

### DIFF
--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C1290FF2E085195002A5E67 /* DeviceStatusMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1290FE2E085195002A5E67 /* DeviceStatusMediator.swift */; };
 		0C2F8C4D2D512C34003A9DA0 /* PlainTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2F8C4C2D512C34003A9DA0 /* PlainTextField.swift */; };
 		2D48F35127609CDE004B27BE /* HistoryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D48F35027609CDE004B27BE /* HistoryCard.swift */; };
 		2D48F3532760A2D8004B27BE /* PrimaryFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D48F3522760A2D8004B27BE /* PrimaryFont.swift */; };
@@ -428,6 +429,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0C1290FE2E085195002A5E67 /* DeviceStatusMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceStatusMediator.swift; sourceTree = "<group>"; };
 		0C2F8C4C2D512C34003A9DA0 /* PlainTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextField.swift; sourceTree = "<group>"; };
 		2D48F35027609CDE004B27BE /* HistoryCard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HistoryCard.swift; sourceTree = "<group>"; };
 		2D48F3522760A2D8004B27BE /* PrimaryFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryFont.swift; sourceTree = "<group>"; };
@@ -2351,6 +2353,7 @@
 				6DAA6CB029BF482E002329A8 /* AuthenticatedStateMediator.swift */,
 				6DAA6CB229BF7155002329A8 /* OnboardingMediator.swift */,
 				6D7DE0D32ACB178800BFAACA /* DatabaseVersionMediator.swift */,
+				0C1290FE2E085195002A5E67 /* DeviceStatusMediator.swift */,
 			);
 			path = StateMediators;
 			sourceTree = "<group>";
@@ -2867,6 +2870,7 @@
 				2DA5F86427566C3600D8DD29 /* TCError.swift in Sources */,
 				6DC5643D28B91EFE003D540B /* NavbarButton.swift in Sources */,
 				6D3DF92829920AA800B8A430 /* UnknownNetworkColorsGenerator.swift in Sources */,
+				0C1290FF2E085195002A5E67 /* DeviceStatusMediator.swift in Sources */,
 				2DA5F86627566C3600D8DD29 /* TCText.swift in Sources */,
 				6D755C092A6FECCD00A73E20 /* JdenticonViewPreviews.swift in Sources */,
 				6DA9DAE929E5831C009CC12C /* ManageNetworkDetailsService.swift in Sources */,

--- a/ios/PolkadotVault/Core/Airgap/AirgapMediator.swift
+++ b/ios/PolkadotVault/Core/Airgap/AirgapMediator.swift
@@ -36,7 +36,7 @@ final class AirgapMediator: AirgapMediating {
     private let notificationCenter: NotificationCenter
     private let locationManager: LocationServicesManaging.Type
     private var wifiSubject = CurrentValueSubject<Bool, Never>(false)
-    private var airplaneSubject = CurrentValueSubject<Bool, Never>(false)
+    private var airplaneSubject = CurrentValueSubject<Bool, Never>(true)
     private var locationSubject = CurrentValueSubject<Bool, Never>(false)
 
     var airgapPublisher: AnyPublisher<AirgapState, Never> {

--- a/ios/PolkadotVault/Protocols/PathMonitorProtocol.swift
+++ b/ios/PolkadotVault/Protocols/PathMonitorProtocol.swift
@@ -27,6 +27,9 @@ protocol PathMonitorProtocol: AnyObject {
     /// be ignored.
     /// - Parameter queue:
     func start(queue: DispatchQueue)
+
+    // Cancels the connection monitoring
+    func cancel()
 }
 
 extension NWPathMonitor: PathMonitorProtocol {}

--- a/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
@@ -132,7 +132,7 @@ private extension MainScreenContainer.ViewModel {
     }
 
     func presentNoAirgapOnStart() {
-        if isPresentingNoAirgap, onboardingMediator.isUserOnboarded {
+        if onboardingMediator.isUserOnboarded {
             isPresentingNoAirgap = true
         }
     }

--- a/ios/PolkadotVault/Screens/Onboarding/NoAirgapView.swift
+++ b/ios/PolkadotVault/Screens/Onboarding/NoAirgapView.swift
@@ -148,7 +148,7 @@ extension NoAirgapView {
 
         init(
             mode: Mode,
-            airgapMediator: AirgapMediating = AirgapMediatorAssembler().assemble(),
+            airgapMediator: AirgapMediating = ServiceLocator.airgapMediator,
             onActionTap: @escaping () -> Void
         ) {
             self.mode = mode
@@ -167,7 +167,6 @@ extension NoAirgapView {
                     self?.updateActionState()
                 }
                 .store(in: cancelBag)
-            airgapMediator.startMonitoringAirgap()
         }
 
         func onDoneTap() {

--- a/ios/PolkadotVault/StateMediators/AppLaunchMediator.swift
+++ b/ios/PolkadotVault/StateMediators/AppLaunchMediator.swift
@@ -9,7 +9,6 @@ import Foundation
 
 protocol AppLaunchMediating: AnyObject {
     func finaliseInitialisation(
-        _ isConnected: Bool,
         _ completion: @escaping (Result<Void, ServiceError>) -> Void
     )
 }
@@ -30,11 +29,10 @@ final class AppLaunchMediator: ObservableObject, AppLaunchMediating {
     }
 
     func finaliseInitialisation(
-        _ isConnected: Bool,
         _ completion: @escaping (Result<Void, ServiceError>) -> Void
     ) {
         if databaseMediator.isDatabaseAvailable() {
-            initialiseOnboardedUserRun(isConnected, completion)
+            initialiseOnboardedUserRun(completion)
         } else {
             initialiseFirstRun(completion)
         }
@@ -47,15 +45,11 @@ final class AppLaunchMediator: ObservableObject, AppLaunchMediating {
     }
 
     private func initialiseOnboardedUserRun(
-        _ isConnected: Bool,
         _ completion: @escaping (Result<Void, ServiceError>) -> Void
     ) {
         seedsMediator.refreshSeeds()
         backendService.performCall({
             try initNavigation(dbname: self.databaseMediator.databaseName, seedNames: self.seedsMediator.seedNames)
-            if isConnected {
-                try? historyDeviceWasOnline()
-            }
         }, completion: completion)
     }
 }

--- a/ios/PolkadotVault/StateMediators/DeviceStatusMediator.swift
+++ b/ios/PolkadotVault/StateMediators/DeviceStatusMediator.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+protocol DeviceStatusMediating {
+    func deviceBecameOnline()
+    func deviceWentOffline()
+}
+
+// Class is designed to track and log once device became online
+final class DeviceStatusMediator {
+    enum State {
+        case notReported
+        case reported
+        case reporting
+
+        var alredyReported: Bool {
+            switch self {
+            case .notReported:
+                false
+            case .reporting,
+                 .reported:
+                true
+            }
+        }
+    }
+
+    private let backendService: BackendService
+    private var state: State = .notReported
+
+    init(backendService: BackendService = BackendService()) {
+        self.backendService = backendService
+    }
+}
+
+extension DeviceStatusMediator: DeviceStatusMediating {
+    func deviceBecameOnline() {
+        guard !state.alredyReported else {
+            return
+        }
+
+        backendService.performCall({
+            try historyDeviceWasOnline()
+        }, completion: { [weak self] (result: Result<Void, ErrorDisplayed>) in
+            switch result {
+            case .success:
+                self?.state = .reported
+            case .failure:
+                self?.state = .notReported
+            }
+        })
+    }
+
+    func deviceWentOffline() {
+        state = .notReported
+    }
+}

--- a/ios/PolkadotVault/StateMediators/OnboardingMediator.swift
+++ b/ios/PolkadotVault/StateMediators/OnboardingMediator.swift
@@ -13,6 +13,8 @@ import SwiftUI
 protocol OnboardingMediating: AnyObject {
     var onboardingDone: AnyPublisher<Bool, Never> { get }
 
+    var isUserOnboarded: Bool { get }
+
     func onboard(verifierRemoved: Bool)
 }
 
@@ -25,6 +27,10 @@ final class OnboardingMediator: OnboardingMediating {
         onboardingDoneSubject.eraseToAnyPublisher()
     }
 
+    var isUserOnboarded: Bool {
+        databaseMediator.isDatabaseAvailable()
+    }
+
     init(
         navigationInitialisationService: NavigationInitialisationServicing = NavigationInitialisationService(),
         seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
@@ -34,7 +40,7 @@ final class OnboardingMediator: OnboardingMediating {
         self.seedsMediator = seedsMediator
         self.databaseMediator = databaseMediator
         // Set initial state based on database availability
-        onboardingDoneSubject.send(databaseMediator.isDatabaseAvailable())
+        onboardingDoneSubject.send(isUserOnboarded)
     }
 
     func onboard(verifierRemoved: Bool) {

--- a/ios/PolkadotVaultTests/StateMediators/OnboardingMediatorTests.swift
+++ b/ios/PolkadotVaultTests/StateMediators/OnboardingMediatorTests.swift
@@ -83,6 +83,8 @@ final class OnboardingMediatorTests: XCTestCase {
             receivedValue,
             isDatabaseAvailable
         )
+
+        XCTAssertEqual(mediator.isUserOnboarded, isDatabaseAvailable)
     }
 
     func testOnboardingWhenRemoveAllSeedsDoneCallsInitialisationNavigationWithPassedValue() {


### PR DESCRIPTION
## Purpose

The PR improves detection of the Airgap mode with the following logic:

- if the user is already onboarded then the NoAirgap screen is presented after authentication to confirm that the USB is not used

- If the user is not onboarded then the initial NoAirgap screen is not presented since it is already included into the onboarding flow. Fixes #2446 

- Once user is onboarded the subscription to the no airgap mode is setup and NoAirgap view is presented each time the subscription reports the issue

- If the transition from airgap mode to the no airgap mode is detected the event is being logged into the database and presented in the Settings -> Logs