### PR TITLE
fix: Memory consumption during Extrinsic parsing

### DIFF
--- a/rust/parser/src/decoding_with_proof.rs
+++ b/rust/parser/src/decoding_with_proof.rs
@@ -16,8 +16,13 @@ use crate::{
 
 use merkleized_metadata::{types::Hash, verify_metadata_digest, TypeResolver};
 
-use parity_scale_codec::Decode;
+use parity_scale_codec::{DecodeLimit};
 use scale_decode::visitor::decode_with_visitor;
+
+/// To avoid OOM issues during scale decoding
+/// one need to decode_all_with_depth_limit with a proper depth limit.
+/// Typically stack has 1MB limit, choose the depth base on it.
+const DECODING_DEPTH_LIMIT: u32 = 1000;
 
 fn verify_decoded_metadata_hash(
     output: &ExtensionsOutput,
@@ -67,7 +72,7 @@ fn verify_genesis_hash(
 }
 
 pub fn decode_metadata_proof(data: &mut &[u8]) -> Result<MetadataProof, Error> {
-    MetadataProof::decode(data)
+    MetadataProof::decode_with_depth_limit(DECODING_DEPTH_LIMIT, data)
         .map_err(|_| Error::Decoding(ParserDecodingError::MetadataProofExpected))
 }
 

--- a/rust/parser/src/state_machine.rs
+++ b/rust/parser/src/state_machine.rs
@@ -332,8 +332,7 @@ impl Visitor for StateMachineParser<'_> {
             .get_first_type(&type_id)
             .map(|v| v.path);
 
-        let seq_items: Vec<_> = value.collect();
-        let items_count = seq_items.len();
+        let items_count = value.remaining();
 
         let input = StateInputCompound {
             name: None,
@@ -348,7 +347,7 @@ impl Visitor for StateMachineParser<'_> {
         let output = visitor.state.process_sequence(&input, visitor.indent)?;
         visitor.apply(output);
 
-        for (index, field_result) in seq_items.into_iter().enumerate() {
+        for (index, field_result) in value.enumerate() {
             visitor.push_indent();
 
             let field = field_result.clone()?;
@@ -462,8 +461,8 @@ impl Visitor for StateMachineParser<'_> {
             .type_registry
             .get_first_type(&type_id)
             .map(|v| v.path);
-        let items: Vec<_> = value.collect();
-        let items_count = value.count();
+
+        let items_count = value.remaining();
 
         let input = StateInputCompound {
             name: None,
@@ -480,7 +479,7 @@ impl Visitor for StateMachineParser<'_> {
             .process_tuple(&input, visitor.indent)?;
         visitor.apply(output);
 
-        for (index, field_result) in items.into_iter().enumerate() {
+        for (index, field_result) in value.enumerate() {
             visitor.push_indent();
 
             let field = field_result?;
@@ -525,8 +524,8 @@ impl Visitor for StateMachineParser<'_> {
             .get_enum_variant_type(&type_id, value.index() as u32)
             .map(|v| v.path);
 
-        let fields: Vec<_> = value.fields().collect();
-        let fields_count = fields.len();
+        let fields_count = value.fields().remaining();
+        let variant_index = value.index();
 
         let input = StateInputCompound {
             name: Some(value.name().to_string()),
@@ -543,14 +542,14 @@ impl Visitor for StateMachineParser<'_> {
             .process_variant(&input, visitor.indent)?;
         visitor.apply(output);
 
-        for (index, field_result) in fields.into_iter().enumerate() {
+        for (index, field_result) in value.fields().enumerate() {
             visitor.push_indent();
 
             let field = field_result?;
             let field_name = field.name().map(|name| name.to_string());
             let type_name = visitor.type_registry.get_enum_field_type_name(
                 &type_id,
-                value.index() as u32,
+                variant_index as u32,
                 index,
             );
 
@@ -594,8 +593,8 @@ impl Visitor for StateMachineParser<'_> {
             .type_registry
             .get_first_type(&type_id)
             .map(|v| v.path);
-        let items: Vec<_> = value.collect();
-        let items_count = items.len();
+
+        let items_count = value.remaining();
 
         let input = StateInputCompound {
             name: None,
@@ -612,7 +611,7 @@ impl Visitor for StateMachineParser<'_> {
             .process_array(&input, visitor.indent)?;
         visitor.apply(output);
 
-        for (index, field) in items.into_iter().enumerate() {
+        for (index, field) in value.enumerate() {
             visitor.push_indent();
 
             let field_result = field.clone()?;


### PR DESCRIPTION
## Purpose

The PR removes memory pre-allocation during scale decoding based on metadata proof in `StateMachineParser`. Instead of forcing vector allocation in the visit methods original iterator passed in the method itself is used now.  The latter ensures that memory consumption is proportional to current decoding progress.

Also, the PR add depth limits to the Metadata Proof decoding following best practice.
